### PR TITLE
fix: bug in example test case in lesson.md

### DIFF
--- a/week15/lesson.md
+++ b/week15/lesson.md
@@ -243,9 +243,9 @@ class TestCat(unittest.TestCase):
         result = cat.speak()
 
         # assert
-        self.assertIn(result, "meows")
-        self.assertIn(result, "Whiskers")
-        self.assertNotIn(result, "moo")
+        self.assertIn("meows", result)
+        self.assertIn("Whiskers", result)
+        self.assertNotIn("moo", result)
 
 ```
 


### PR DESCRIPTION
Incorrect order of arguments in TestCat.test_speak() assertions.